### PR TITLE
EOS balance restriction

### DIFF
--- a/Sources/SwiftyEOS/Network/Chain/EOSRPC+Chain.swift
+++ b/Sources/SwiftyEOS/Network/Chain/EOSRPC+Chain.swift
@@ -43,7 +43,7 @@ extension EOSRPC {
             }
             let balanceString = resultArray!.first
             let parts = balanceString!.components(separatedBy: " ")
-            if parts.count != 2 || parts[1] != "EOS" {
+            if parts.count != 2 {
                 completion(NSDecimalNumber.zero, nil)
                 return
             }


### PR DESCRIPTION
Removed a weird currency restriction when getting balance. 
You clearly can specify a currency you want to request in the function and it works just fine without this check.